### PR TITLE
Display more then one post correctly and use slugs

### DIFF
--- a/BuildTaskList.cs
+++ b/BuildTaskList.cs
@@ -1,4 +1,5 @@
 ﻿
+
 namespace SeBlog
 {
     using System.Collections.Generic;
@@ -7,7 +8,7 @@ namespace SeBlog
     {
         public static Dictionary<string, string> TitleToFile = new Dictionary<string,string>
         {
-            { "posts/2020/06/06/Writing my first post and a blog engine","/posts/27.05.2020-First-post.md"},
+            { "posts/2020/06/06/writing-my-first-post-and-a-blog-engine","/posts/27.05.2020-First-post.md"},
         };
     }
 }

--- a/BuildTaskList.tt
+++ b/BuildTaskList.tt
@@ -4,6 +4,8 @@
 <#@ import namespace="System.Globalization" #>
 <#@ import namespace="System.IO" #>
 <#@ import namespace="System.Linq" #>
+<#@ assembly name="$(TargetDir)SeBlog.dll" #>
+
 <#
     const string path = "wwwroot/posts";
     var postPaths = Directory.GetFiles(path, "*.md", SearchOption.AllDirectories);
@@ -25,9 +27,8 @@
             frontTags.First(tag => tag.StartsWith("published:")).Replace("published:", "").Replace("\"", "").Trim();
         Console.WriteLine($"Date {publishedString}");
         var publishedDate = DateTime.ParseExact(publishedString, "G", CultureInfo.InvariantCulture);
-        return $"posts/{publishedDate.Year}/{publishedDate.Month:00}/{publishedDate.Day:00}/{title}";
+        return $"posts/{publishedDate.Year}/{publishedDate.Month:00}/{publishedDate.Day:00}/{title.GenerateSlug()}";
     }
-
 #>
 
 namespace SeBlog

--- a/Components/BlogPostShort.razor
+++ b/Components/BlogPostShort.razor
@@ -2,14 +2,23 @@
 
 
 <div class="card w-100 shadow-sm" style="border-radius: 20px; margin-top: 20px;">
+
     <div class="card-body" style="margin-left: 10px;">
-        <h5 class="card-title">@Blog.Title</h5> <h6 class="card-subtitle mb-2 text-muted">Published @Blog.Published.ToString("Y")</h6>
-        <div class="row card-text">
-            <div class="col-auto">
-                @Blog.Description
+        <div class="row">
+
+            <div class="col-sm-11" style="max-width: calc(100% - 40px);">
+                <h5 class="card-title">@Blog.Title</h5>
+                <div class="row card-text">
+                    <div class="col-auto">
+                        @Blog.Description
+                    </div>
+                    <div class="col-auto">
+                        <button @onclick="GotoBlog" class="btn btn-link" style="padding-left: 0;">read more</button>
+                    </div>
+                </div>
             </div>
-            <div class="col-auto">
-                <button @onclick="GotoBlog" class="btn btn-link" style="padding-left: 0;">read more</button>
+            <div style="min-width: 20px; max-width: 30px;" >
+                <p class="card-subtitle mb-2 text-muted" style="margin-top: 10px;-ms-writing-mode:tb-rl; writing-mode: vertical-rl; transform:rotate(180deg); vertical-align: bottom">@Blog.Published.ToString("Y")</p>
             </div>
         </div>
     </div>

--- a/Post.cs
+++ b/Post.cs
@@ -1,4 +1,8 @@
 ﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
 
 namespace SeBlog
 {
@@ -16,7 +20,32 @@ namespace SeBlog
 
         public static string GetKey(int year, int month, int day, string title)
         {
-            return $"posts/{year}/{month:00}/{day:00}/{title.Trim()}";
+            return $"posts/{year}/{month:00}/{day:00}/{title.GenerateSlug()}";
+        }
+    }
+    
+    public static class Slug
+    {
+        public static string GenerateSlug(this string phrase)
+        {
+            string str = phrase.RemoveDiacritics().ToLower();
+            // invalid chars           
+            str = Regex.Replace(str, @"[^a-z0-9\s-]", "");
+            // convert multiple spaces into one space   
+            str = Regex.Replace(str, @"\s+", " ").Trim();
+            // cut and trim 
+            str = str.Substring(0, str.Length <= 45 ? str.Length : 45).Trim();
+            str = Regex.Replace(str, @"\s", "-"); // hyphens   
+            return str;
+        }
+ 
+        public static string RemoveDiacritics(this string text)
+        {
+            var s = new string(text.Normalize(NormalizationForm.FormD)
+                .Where(c => CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)
+                .ToArray());
+ 
+            return s.Normalize(NormalizationForm.FormC);
         }
     }
 }

--- a/wwwroot/posts/27.05.2020-First-post.md
+++ b/wwwroot/posts/27.05.2020-First-post.md
@@ -82,7 +82,7 @@ Translating the markdown into a readable Html page is super easy thanks to [Mark
 
 Here is a stripped down version of the rendering component code:
 
-```razor
+``` csharp
 @using Markdig
 
 @if (Markdown == null)


### PR DESCRIPTION
In order to have more readable urls the t4 template use a apply's a slug to the title, previously it still contained whitespaces and other characters that made the url unreadable due to escaping. Additionally applied some stilling to let the post list look more "fresh"
